### PR TITLE
replace hardcoded app path with builder.getAppPath()

### DIFF
--- a/app/adapter/index.js
+++ b/app/adapter/index.js
@@ -108,7 +108,7 @@ See https://kit.svelte.dev/docs/page-options#prerender for more details`,
 				});
 			});
 
-			const HTML_assets = await glob("_app/**/*", {
+			const HTML_assets = await glob(builder.getAppPath()+"/**/*", {
 				cwd: pages,
 				dot: true,
 				absolute: false,
@@ -116,7 +116,7 @@ See https://kit.svelte.dev/docs/page-options#prerender for more details`,
 			});
 
 			HTML_assets.forEach(async () => {
-				let regex_input = new RegExp(`([^.])(/_app/immutable)`, "g");
+				let regex_input = new RegExp(`([^.])(/${builder.getAppPath()}/immutable)`, "g");
 
 				await replace.sync({
 					files: [`${pages}/**/*`],


### PR DESCRIPTION
Right now if you change the appDir parameter in kit.config it breaks functionality for this adapter. Using builder.getAppPath fixes this issue because it uses the user inputted directory rather than hard coding the default one.